### PR TITLE
Add maximem-synap-langgraph to Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,8 +1067,9 @@ Browse the full template catalog here:
 
 | Package | Description | Registry |
 |---|---|---|
-| [MOSS LangGraph](https://pypi.org/project/moss-langgraph/) | Cryptographic signing for LangGraph workflows. Add tamper-proof audit trails with ML-DSA-44 post-quantum signatures to node outputs and state transitions. | [![PyPI](https://img.shields.io/pypi/v/moss-langgraph)](https://pypi.org/project/moss-langgraph/) |
 | [langchain-colony](https://pypi.org/project/langchain-colony/) | LangChain integration for The Colony — the AI agent internet. Provides LangChain-native tools for agents to post, comment, vote, message, and interact on a social platform with 780+ AI agents. | [![PyPI](https://img.shields.io/pypi/v/langchain-colony)](https://pypi.org/project/langchain-colony/) |
+| [maximem-synap-langgraph](https://pypi.org/project/maximem-synap-langgraph/) | LangGraph `BaseStore` + `BaseCheckpointSaver` backed by Synap, a managed long-term memory layer for cross-thread agent recall. | [![PyPI](https://img.shields.io/pypi/v/maximem-synap-langgraph)](https://pypi.org/project/maximem-synap-langgraph/) |
+| [MOSS LangGraph](https://pypi.org/project/moss-langgraph/) | Cryptographic signing for LangGraph workflows. Add tamper-proof audit trails with ML-DSA-44 post-quantum signatures to node outputs and state transitions. | [![PyPI](https://img.shields.io/pypi/v/moss-langgraph)](https://pypi.org/project/moss-langgraph/) |
 
 <div align="center">
 


### PR DESCRIPTION
Hi @vonzosten — thanks for the feedback on #51. Re-submitting with the contributing guidelines in mind:

- **Category:** moved to `📦 Packages` (correct fit — `maximem-synap-langgraph` is an installable PyPI package for extending LangGraph workflows, not a full app/tool)
- **Alphabetical order:** placed between `langchain-colony` and `MOSS LangGraph`
- **Description:** under 200 chars, clearly states what LangGraph surfaces it provides
- **Format:** matches existing Packages table format (PyPI link + description + PyPI badge)

[maximem-synap-langgraph](https://pypi.org/project/maximem-synap-langgraph/) is the LangGraph adapter for [Synap](https://maximem.ai), a managed long-term memory layer for AI agents — provides a `SynapStore` (`BaseStore`) for cross-thread memory and a `SynapCheckpointSaver`. Open source: https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations/synap-langgraph