### PR TITLE
Add OpenBusiness to Business Intelligence & Market Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@ Browse the full template catalog here:
 | Project | Description | GitHub Stars |
 |---|---|---|
 | [oba2311/analyst_agent](https://github.com/oba2311/analyst_agent) | Marketing analysis agent with trend/sentiment analysis and report generation | ![GitHub stars](https://img.shields.io/github/stars/oba2311/analyst_agent?style=social)<br>![Last commit](https://img.shields.io/github/last-commit/oba2311/analyst_agent) |
+| [wanikua/OpenBusiness](https://github.com/wanikua/OpenBusiness) | Evidence-first business model research CLI; runs LangGraph analyst agents for GTM, unit economics, and moat, labeling every claim verified, inferred, or missing | ![GitHub stars](https://img.shields.io/github/stars/wanikua/OpenBusiness?style=social)<br>![Last commit](https://img.shields.io/github/last-commit/wanikua/OpenBusiness) |
 
 
 <div align="center">


### PR DESCRIPTION
Adds [OpenBusiness](https://github.com/wanikua/OpenBusiness) under **Community Projects → 📊 Business Intelligence & Market Research**.

OpenBusiness is an open-source (MIT) Python CLI on PyPI that uses a linear **LangGraph** StateGraph of analyst agents (evidence collection → JTBD → value prop → GTM → unit economics → moat → synthesis → stress test → finalize) to produce an evidence-labeled Markdown business-model report. Every claim is tagged verified, inferred, or missing.

Checklist:
- [x] Uses LangChain/LangGraph
- [x] Actively maintained
- [x] Description under 200 chars
- [x] Correct category, alphabetical order
- [x] GitHub stars + last-commit badges