### PR TITLE
Add langgraph-checkpoint-grafomem to Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1071,6 +1071,7 @@ Browse the full template catalog here:
 |---|---|---|
 | [MOSS LangGraph](https://pypi.org/project/moss-langgraph/) | Cryptographic signing for LangGraph workflows. Add tamper-proof audit trails with ML-DSA-44 post-quantum signatures to node outputs and state transitions. | [![PyPI](https://img.shields.io/pypi/v/moss-langgraph)](https://pypi.org/project/moss-langgraph/) |
 | [langchain-colony](https://pypi.org/project/langchain-colony/) | LangChain integration for The Colony — the AI agent internet. Provides LangChain-native tools for agents to post, comment, vote, message, and interact on a social platform with 780+ AI agents. | [![PyPI](https://img.shields.io/pypi/v/langchain-colony)](https://pypi.org/project/langchain-colony/) |
+| [langgraph-checkpoint-grafomem](https://pypi.org/project/langgraph-checkpoint-grafomem/) | Signed, tamper-evident LangGraph checkpoints with a verifiable Ed25519 erasure receipt on `delete_thread` — provable "right to be forgotten" for agent memory. | [![PyPI](https://img.shields.io/pypi/v/langgraph-checkpoint-grafomem)](https://pypi.org/project/langgraph-checkpoint-grafomem/) |
 
 <div align="center">
 


### PR DESCRIPTION
Adds langgraph-checkpoint-grafomem to the Packages table per contributing guidelines (PyPI badge, <200-char description).