### PR TITLE
Add echakrabarti/no-epicycle to Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,7 @@ Browse the full template catalog here:
 | Package | Description | Registry |
 |---|---|---|
 | [MOSS LangGraph](https://pypi.org/project/moss-langgraph/) | Cryptographic signing for LangGraph workflows. Add tamper-proof audit trails with ML-DSA-44 post-quantum signatures to node outputs and state transitions. | [![PyPI](https://img.shields.io/pypi/v/moss-langgraph)](https://pypi.org/project/moss-langgraph/) |
+| [noepicycle](https://pypi.org/project/noepicycle/) | LangGraph supervisor agent that wraps agentic coding loops, detects diminishing returns via convergence analysis, and routes between models to prevent token cost spiralling | [![PyPI](https://img.shields.io/pypi/v/noepicycle)](https://pypi.org/project/noepicycle/) |
 | [langchain-colony](https://pypi.org/project/langchain-colony/) | LangChain integration for The Colony — the AI agent internet. Provides LangChain-native tools for agents to post, comment, vote, message, and interact on a social platform with 780+ AI agents. | [![PyPI](https://img.shields.io/pypi/v/langchain-colony)](https://pypi.org/project/langchain-colony/) |
 
 <div align="center">


### PR DESCRIPTION
## Summary

- What did you add, remove, or change?
- Added noepicycle to the Packages section — a LangGraph-native supervisor 
  agent that wraps agentic coding loops and prevents token cost spiralling 
  by detecting diminishing returns via convergence analysis (delta threshold, 
  absolute plateau tracking, fixation detection via SHA256 solution hashing). 
  Dynamically routes between Claude models on plateau/regression/fixation 
  signals. Benchmarked at 43% mean token savings on iterative tasks at equal 
  or better accuracy. Published to PyPI: pip install noepicycle.

## Section

- Which README section did you update?
Packages
## Checklist

- [X ] I placed the entry in the most appropriate category
- [X ] I verified the project or resource link works
- [ X] If this is a GitHub repository, it is not archived
- [ X] If this is a Community Project, it has recent activity and is not stale
- [X ] I followed the formatting style used in the README
- [X ] I updated related badges, descriptions, or section placement if needed

## Notes

- Anything reviewers should know?
Active development